### PR TITLE
Fix SSR store reference bug

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -17,7 +17,7 @@ import CssInjector from "./helpers/cssInjector";
 // root reducer
 import { rootReducer, initialState, IAppState } from "./rootReducer";
 // routes
-import routes from "./routes";
+import createRoute from "./routes";
 
 // Load bootstrap
 // If you don't want to use Bootstrap delete below lines and relevant packages
@@ -99,6 +99,7 @@ const appHistory = ReactRouterRedux.syncHistoryWithStore(
 );
 
 export const appStore = store;
+const routes = createRoute(store);
 
 // Browser Side Rendering to develop React Web-app
 if (!EnvChecker.isServer()) {

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -14,32 +14,34 @@ import BasicSettingsDocumentationComponent from "./components/documentation/basi
 // actions
 import { getUserInfo } from "./components/user/actions";
 // store
-import { appStore } from "./";
+//import { store } from "./";
 
-const routeMap = ([
-  <Route path="/" component={RootComponent}>
-    <Route
-      path="users/:username"
-      getComponent={async (nextState: Router.RouterState, callback: Function) => {
-        const newUsername = nextState.params["username"];
-        try {
-          await appStore.dispatch(getUserInfo(newUsername));
-          callback(null, GithubUserContainer);
-        } catch (err) {
-          // return callback(null, Status404);
-          throw err;
-        }
-      }}
-    />
-    <Route path="docs" component={DocumentationComponent}>
-      <Route path="beforestart" component={BeforeStartDocumentationComponent} />
-      <Route path="installation" component={InstallationDocumentationComponent} />
-      <Route path="basicsettings" component={BasicSettingsDocumentationComponent} />
-      <Route path="advancedsettings" component={AdvancedSettingsDocumentationComponent} />
-      <IndexRoute component={IntroDocumentationComponent} />
-    </Route>
-    <IndexRoute component={HomeComponent} />
-  </Route>,
-]);
+const createRoute = (store) => {
+  return ([
+    <Route path="/" component={RootComponent}>
+      <Route
+        path="users/:username"
+        getComponent={async (nextState: Router.RouterState, callback: Function) => {
+          const newUsername = nextState.params["username"];
+          try {
+            await store.dispatch(getUserInfo(newUsername));
+            callback(null, GithubUserContainer);
+          } catch (err) {
+            // return callback(null, Status404);
+            throw err;
+          }
+        }}
+      />
+      <Route path="docs" component={DocumentationComponent}>
+        <Route path="beforestart" component={BeforeStartDocumentationComponent} />
+        <Route path="installation" component={InstallationDocumentationComponent} />
+        <Route path="basicsettings" component={BasicSettingsDocumentationComponent} />
+        <Route path="advancedsettings" component={AdvancedSettingsDocumentationComponent} />
+        <IndexRoute component={IntroDocumentationComponent} />
+      </Route>
+      <IndexRoute component={HomeComponent} />
+    </Route>,
+  ]);
+}
 
-export default routeMap;
+export default createRoute;

--- a/app/server.tsx
+++ b/app/server.tsx
@@ -15,7 +15,7 @@ import EnvChecker from "./helpers/envChecker";
 // root reducer
 import { rootReducer, initialState } from "./rootReducer";
 // routes
-import routes from "./routes";
+import createRoute from "./routes";
 // deploy
 import * as fs from "fs";
 import * as DeployConfig from "../scripts/builds/config";
@@ -32,6 +32,7 @@ const store = createStore(
   // TODO: Add InitialState and Define State types to change 'any' type
   applyMiddleware(routerMid, thunkMiddleware),
 );
+const routes = createRoute(store);
 
 export async function serverSideRender(requestUrl: string, scriptPath: string) {
   let renderedHTML: string;


### PR DESCRIPTION
When generating HTMLs with renderToString at app/server.tsx, the route at app/routes.tsx refers different appStore because appStore came from app/index.tsx(client side codes). To fix the bug, I made app/routes.tsx code which simply returns function to make Route with appStore as argument.
Hope this works well.